### PR TITLE
Reto 6: Números primos en Go

### DIFF
--- a/retos/Reto-6/PChaparro/go.mod
+++ b/retos/Reto-6/PChaparro/go.mod
@@ -1,0 +1,11 @@
+module github.com/pedrovelasquez9/retos-de-programacion/retos/Reto-6/PChaparro
+
+go 1.19
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/retos/Reto-6/PChaparro/go.sum
+++ b/retos/Reto-6/PChaparro/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/retos/Reto-6/PChaparro/primes.go
+++ b/retos/Reto-6/PChaparro/primes.go
@@ -1,0 +1,39 @@
+package primes
+
+// getTrueFilledArray returns an array of the given size filled with true values
+func getTrueFilledArray(size uint) []bool {
+	var arr = make([]bool, size)
+	for i := range arr {
+		arr[i] = true
+	}
+	return arr
+}
+
+// SieveOfEratosThenes returns a slice of prime numbers up to the given number
+func SieveOfEratosthenes(n uint) []uint {
+	// Initially assume all numbers are prime
+	isPrime := getTrueFilledArray(n + 1)
+
+	for i := uint(2); i*i <= n; i++ {
+		// If the number was already marked as not prime, skip it
+		if !isPrime[i] {
+			continue
+		}
+
+		// Mark all multiples of i as not prime
+		for j := i * 2; j <= n; j += i {
+			isPrime[j] = false
+		}
+	}
+
+	// Collect and return all prime numbers
+	var primes []uint
+
+	for i := uint(2); i <= n; i++ {
+		if isPrime[i] {
+			primes = append(primes, i)
+		}
+	}
+
+	return primes
+}

--- a/retos/Reto-6/PChaparro/primes_test.go
+++ b/retos/Reto-6/PChaparro/primes_test.go
@@ -1,0 +1,55 @@
+package primes_test
+
+import (
+	"testing"
+
+	primes "github.com/pedrovelasquez9/retos-de-programacion/retos/Reto-6/PChaparro"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSieveOfEratosthenes(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test 1
+	result := primes.SieveOfEratosthenes(1)
+	expected := []uint{}
+	assert.Equal(len(expected), len(result))
+	assert.ElementsMatch(expected, result)
+
+	// Test 2
+	result = primes.SieveOfEratosthenes(2)
+	expected = []uint{2}
+	assert.Equal(len(expected), len(result))
+	assert.ElementsMatch(expected, result)
+
+	// Test 3
+	result = primes.SieveOfEratosthenes(10)
+	expected = []uint{2, 3, 5, 7}
+	assert.Equal(len(expected), len(result))
+	assert.ElementsMatch(expected, result)
+
+	// Test 4
+	result = primes.SieveOfEratosthenes(20)
+	expected = []uint{2, 3, 5, 7, 11, 13, 17, 19}
+	assert.Equal(len(expected), len(result))
+	assert.ElementsMatch(expected, result)
+
+	// Test 5
+	result = primes.SieveOfEratosthenes(100)
+	expected = []uint{
+		2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31,
+		37, 41, 43, 47, 53, 59, 61, 67, 71, 73,
+		79, 83, 89, 97,
+	}
+	assert.Equal(len(expected), len(result))
+	assert.ElementsMatch(expected, result)
+
+	// As the expected result of the following test is too large, we will only check the length of the result
+	// Test 6
+	result = primes.SieveOfEratosthenes(1000)
+	assert.Equal(168, len(result))
+
+	// Test 7
+	result = primes.SieveOfEratosthenes(10000)
+	assert.Equal(1229, len(result))
+}


### PR DESCRIPTION
Incluye: 

- Solución del reto usando el algoritmo de "La Criba de Eratóstenes". 
- Tests para la solución implementada. 